### PR TITLE
add optionnal `ch.` prefix to ext name to prevent conflicts

### DIFF
--- a/ch_queries_ppx/ch_queries_ppx.ml
+++ b/ch_queries_ppx/ch_queries_ppx.ml
@@ -646,8 +646,8 @@ let query_extension name =
     Ast_pattern.(single_expr_payload __)
     expand_query
 
-let from_extension =
-  Extension.V3.declare "f" Extension.Context.expression
+let from_extension name =
+  Extension.V3.declare name Extension.Context.expression
     Ast_pattern.(single_expr_payload __)
     expand_from
 
@@ -668,13 +668,10 @@ let uexpr_extension name =
 
 let rules =
   [
-    Context_free.Rule.extension (query_extension "q");
     Context_free.Rule.extension (query_extension "ch.q");
-    Context_free.Rule.extension (expr_extension "e");
+    Context_free.Rule.extension (from_extension "ch.f");
     Context_free.Rule.extension (expr_extension "ch.e");
-    Context_free.Rule.extension (typ_extension "t");
     Context_free.Rule.extension (typ_extension "ch.t");
-    Context_free.Rule.extension (uexpr_extension "eu");
     Context_free.Rule.extension (uexpr_extension "ch.eu");
   ]
 

--- a/ch_queries_ppx/ch_queries_ppx.ml
+++ b/ch_queries_ppx/ch_queries_ppx.ml
@@ -669,13 +669,13 @@ let uexpr_extension name =
 let rules =
   [
     Context_free.Rule.extension (query_extension "q");
-    Context_free.Rule.extension (query_extension "clickhouse.q");
+    Context_free.Rule.extension (query_extension "ch.q");
     Context_free.Rule.extension (expr_extension "e");
-    Context_free.Rule.extension (expr_extension "clickhouse.e");
+    Context_free.Rule.extension (expr_extension "ch.e");
     Context_free.Rule.extension (typ_extension "t");
-    Context_free.Rule.extension (typ_extension "clickhouse.t");
+    Context_free.Rule.extension (typ_extension "ch.t");
     Context_free.Rule.extension (uexpr_extension "eu");
-    Context_free.Rule.extension (uexpr_extension "clickhouse.eu");
+    Context_free.Rule.extension (uexpr_extension "ch.eu");
   ]
 
 let () = Driver.register_transformation ~rules "queries_ppx"

--- a/ch_queries_ppx/ch_queries_ppx.ml
+++ b/ch_queries_ppx/ch_queries_ppx.ml
@@ -641,8 +641,8 @@ let expand_typ ~ctxt:_ expr =
       [%type: ([%t n], [%t t]) Ch_queries.expr]
   | _ -> Location.raise_errorf "expected a string literal for [%%t ...]"
 
-let query_extension =
-  Extension.V3.declare "q" Extension.Context.expression
+let query_extension name =
+  Extension.V3.declare name Extension.Context.expression
     Ast_pattern.(single_expr_payload __)
     expand_query
 
@@ -651,28 +651,31 @@ let from_extension =
     Ast_pattern.(single_expr_payload __)
     expand_from
 
-let expr_extension =
-  Extension.V3.declare "e" Extension.Context.expression
+let expr_extension name =
+  Extension.V3.declare name Extension.Context.expression
     Ast_pattern.(single_expr_payload __)
     expand_expr
 
-let typ_extension =
-  Extension.V3.declare "t" Extension.Context.core_type
+let typ_extension name =
+  Extension.V3.declare name Extension.Context.core_type
     Ast_pattern.(single_expr_payload __)
     expand_typ
 
-let uexpr_extension =
-  Extension.V3.declare "eu" Extension.Context.expression
+let uexpr_extension name =
+  Extension.V3.declare name Extension.Context.expression
     Ast_pattern.(single_expr_payload __)
     expand_uexpr
 
 let rules =
   [
-    Context_free.Rule.extension query_extension;
-    Context_free.Rule.extension from_extension;
-    Context_free.Rule.extension expr_extension;
-    Context_free.Rule.extension typ_extension;
-    Context_free.Rule.extension uexpr_extension;
+    Context_free.Rule.extension (query_extension "q");
+    Context_free.Rule.extension (query_extension "clickhouse.q");
+    Context_free.Rule.extension (expr_extension "e");
+    Context_free.Rule.extension (expr_extension "clickhouse.e");
+    Context_free.Rule.extension (typ_extension "t");
+    Context_free.Rule.extension (typ_extension "clickhouse.t");
+    Context_free.Rule.extension (uexpr_extension "eu");
+    Context_free.Rule.extension (uexpr_extension "clickhouse.eu");
   ]
 
 let () = Driver.register_transformation ~rules "queries_ppx"

--- a/test/test_with_prefix.t
+++ b/test/test_with_prefix.t
@@ -1,0 +1,25 @@
+all syntax forms can be used with `%ch.*` prefix as well, we test just the `%ch.q` here:
+  $ ./compile_and_run '
+  > let users = [%ch.q "SELECT users.x AS x FROM public.users WHERE users.is_active"];;
+  > #show users
+  > '
+  >>> PREPROCESSING
+  let users =
+    Ch_queries.select ()
+      ~from:
+        (Ch_queries.map_from_scope
+           (Ch_queries.from
+              (Ch_database.Public.users ~alias:"users" ~final:false))
+           (fun (users : _ Ch_queries.scope) ->
+             object
+               method users = users
+             end))
+      ~select:(fun __q ->
+        object
+          method x = __q#users#query (fun __q -> __q#x)
+        end)
+      ~where:(fun __q -> __q#users#query (fun __q -> __q#is_active))
+  >>> RUNNING
+  val users :
+    < x : (Ch_queries.non_null, string) Ch_queries.expr > Ch_queries.scope
+    Ch_queries.select


### PR DESCRIPTION
The idea is that if another ppx has a `%e` extension, this one is still usable with the syntax `%clickhouse.e`.