### PR TITLE
add support for LIKE operator

### DIFF
--- a/ch_queries_ppx/ch_queries_ppx.ml
+++ b/ch_queries_ppx/ch_queries_ppx.ml
@@ -163,6 +163,7 @@ let map_operator_to_expr ~loc op arity =
   match (op, arity) with
   | "OR", 2 -> [%expr Ch_queries.Expr.( || )]
   | "AND", 2 -> [%expr Ch_queries.Expr.( && )]
+  | "LIKE", 2 -> [%expr Ch_queries.Expr.like]
   | "NOT", 1 -> [%expr Ch_queries.Expr.not_]
   | "-", 1 -> [%expr Ch_queries.Expr.negate]
   | ">", 2 -> [%expr Ch_queries.Expr.( > )]

--- a/ch_queries_syntax/lexer.mll
+++ b/ch_queries_syntax/lexer.mll
@@ -15,6 +15,7 @@
     ("FALSE", FALSE);
     ("AND", AND);
     ("OR", OR);
+    ("LIKE", LIKE);
     ("NOT", NOT);
     ("JOIN", JOIN);
     ("INNER", INNER);
@@ -98,6 +99,7 @@
     | Parser.NOT_EQUAL -> "NOT_EQUAL"
     | Parser.AND -> "AND"
     | Parser.OR -> "OR"
+    | Parser.LIKE -> "LIKE"
     | Parser.NOT -> "NOT"
     | Parser.INNER -> "INNER"
     | Parser.JOIN -> "JOIN"

--- a/ch_queries_syntax/parser.mly
+++ b/ch_queries_syntax/parser.mly
@@ -23,7 +23,7 @@
 %token SELECT FROM PREWHERE WHERE AS DOT COLONCOLON
 %token LPAREN RPAREN LBRACKET RBRACKET COMMA
 %token PLUS MINUS STAR SLASH EQUALS GT LT GE LE NOT_EQUAL
-%token AND OR NOT
+%token AND OR NOT LIKE
 %token INNER JOIN LEFT OPTIONAL ON
 %token GROUP BY HAVING ORDER ASC DESC
 %token OVER PARTITION QUALIFY
@@ -42,6 +42,7 @@
 %left OR
 %left AND
 %right NOT
+%nonassoc LIKE
 %left EQUALS GT LT GE LE NOT_EQUAL IN
 %left PLUS MINUS
 %left STAR SLASH
@@ -250,6 +251,8 @@ expr:
     { make_expr $startpos $endpos (E_call (Func (make_id $startpos($2) $endpos($2) "OR"), [e1; e2])) }
   | NOT e=expr
     { make_expr $startpos $endpos (E_call (Func (make_id $startpos($1) $endpos($1) "NOT"), [e])) }
+  | e1=expr LIKE e2=expr
+    { make_expr $startpos $endpos (E_call (Func (make_id $startpos($2) $endpos($2) "LIKE"), [e1; e2])) }
   | MINUS e=expr %prec UMINUS
     { make_expr $startpos $endpos (E_call (Func (make_id $startpos($1) $endpos($1) "-"), [e])) }
   | e1=expr EQUALS e2=expr

--- a/ch_queries_syntax/printer.ml
+++ b/ch_queries_syntax/printer.ml
@@ -157,6 +157,11 @@ let rec pp_expr opts ~parent_prec expr =
               pp_expr opts ~parent_prec:prec left
               ^/^ string "OR"
               ^/^ pp_expr opts ~parent_prec:prec right
+          | "LIKE", [ left; right ] ->
+              parens_if_needed @@ fun prec ->
+              pp_expr opts ~parent_prec:prec left
+              ^/^ string "LIKE"
+              ^/^ pp_expr opts ~parent_prec:prec right
           | "NOT", [ operand ] ->
               parens_if_needed @@ fun prec ->
               string "NOT" ^/^ pp_expr opts ~parent_prec:prec operand

--- a/test/test_like.t
+++ b/test/test_like.t
@@ -1,0 +1,39 @@
+test IN expression with subquery:
+  $ ./compile_and_run "
+  > let users = [%q \"SELECT users.x AS x FROM public.users WHERE (users.x LIKE '123%')\"];;
+  > let sql, _parse_row = Ch_queries.query users @@ fun __q -> Ch_queries.Row.string [%e \"q.x\"]
+  > let () = print_endline sql;;
+  > "
+  >>> PREPROCESSING
+  let users =
+    Ch_queries.select ()
+      ~from:
+        (Ch_queries.map_from_scope
+           (Ch_queries.from
+              (Ch_database.Public.users ~alias:"users" ~final:false))
+           (fun (users : _ Ch_queries.scope) ->
+             object
+               method users = users
+             end))
+      ~select:(fun __q ->
+        object
+          method x = __q#users#query (fun __q -> __q#x)
+        end)
+      ~where:(fun __q ->
+        Ch_queries.Expr.like
+          (__q#users#query (fun __q -> __q#x))
+          (Ch_queries.string "123%"))
+  
+  let sql, _parse_row =
+    Ch_queries.query users @@ fun __q ->
+    Ch_queries.Row.string (__q#q#query (fun __q -> __q#x))
+  
+  let () = print_endline sql
+  >>> RUNNING
+  SELECT q._1
+  FROM (
+    SELECT users.x AS _1 FROM public.users AS users WHERE like(users.x, '123%'))
+    AS q
+
+
+


### PR DESCRIPTION
I think the operator priority is wrong, but I don't really know how to fix it.

For know the printer produces the function `like` instead of operator `LIKE` so there is no need for proper parens in the printer but it would be nice to lift that restriction.