### PR TITLE
Resolve unqualified columns to local scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ scope and returns an expression:
     WHERE users.is_active AND $where
   |}
 val users :
-  where:(< users : < id : (non_null, int number) expr;
+  where:(< id : (non_null, int number) expr; name : (non_null, string) expr;
+           users : < id : (non_null, int number) expr;
                      is_active : (non_null, bool) expr;
                      name : (non_null, string) expr >
                    scope > ->
@@ -71,7 +72,7 @@ val users :
 Finally to generate SQL from the query, one needs to define what exactly to
 select and how to parse each column:
 ```ocaml
-# let sql, parse_row = Ch_queries.query {%q|SELECT id FROM db.users|} Row.(fun __q -> int {%e|q.id|});;
+# let sql, parse_row = Ch_queries.query {%q|SELECT users.id FROM db.users|} Row.(fun __q -> int {%e|q.id|});;
 val sql : string =
   "SELECT q._1 FROM (SELECT users.id AS _1 FROM public.users AS users) AS q"
 val parse_row : json list -> int = <fun>

--- a/test/test_cluster.t
+++ b/test/test_cluster.t
@@ -17,24 +17,38 @@ test cluster syntax parsing:
                          (Ch_queries.from
                             (Ch_database.Public.users ~alias:"users" ~final:false))
                          (fun (users : _ Ch_queries.scope) ->
+                           let __q =
+                             object
+                               method users = users
+                             end
+                           in
                            object
+                             method x = __q#users#query (fun __q -> __q#x)
+  
+                             method is_active =
+                               __q#users#query (fun __q -> __q#is_active)
+  
                              method users = users
                            end))
                     ~select:(fun __q ->
                       object
-                        method x = __q#users#query (fun __q -> __q#x)
-  
-                        method is_active =
-                          __q#users#query (fun __q -> __q#is_active)
+                        method x = __q#x
+                        method is_active = __q#is_active
                       end))
                  ~alias:"users"))
            (fun (users : _ Ch_queries.scope) ->
+             let __q =
+               object
+                 method users = users
+               end
+             in
              object
+               method x = __q#users#query (fun __q -> __q#x)
                method users = users
              end))
       ~select:(fun __q ->
         object
-          method x = __q#users#query (fun __q -> __q#x)
+          method x = __q#x
         end)
       ~where:(fun __q -> __q#users#query (fun __q -> __q#is_active))
   
@@ -71,24 +85,38 @@ test parameterized cluster syntax:
                          (Ch_queries.from
                             (Ch_database.Public.users ~alias:"users" ~final:false))
                          (fun (users : _ Ch_queries.scope) ->
+                           let __q =
+                             object
+                               method users = users
+                             end
+                           in
                            object
+                             method x = __q#users#query (fun __q -> __q#x)
+  
+                             method is_active =
+                               __q#users#query (fun __q -> __q#is_active)
+  
                              method users = users
                            end))
                     ~select:(fun __q ->
                       object
-                        method x = __q#users#query (fun __q -> __q#x)
-  
-                        method is_active =
-                          __q#users#query (fun __q -> __q#is_active)
+                        method x = __q#x
+                        method is_active = __q#is_active
                       end))
                  ~alias:"users"))
            (fun (users : _ Ch_queries.scope) ->
+             let __q =
+               object
+                 method users = users
+               end
+             in
              object
+               method x = __q#users#query (fun __q -> __q#x)
                method users = users
              end))
       ~select:(fun __q ->
         object
-          method x = __q#users#query (fun __q -> __q#x)
+          method x = __q#x
         end)
       ~where:(fun __q -> __q#users#query (fun __q -> __q#is_active))
   

--- a/test/test_in.t
+++ b/test/test_in.t
@@ -12,12 +12,18 @@ test IN expression with subquery:
            (Ch_queries.from
               (Ch_database.Public.users ~alias:"users" ~final:false))
            (fun (users : _ Ch_queries.scope) ->
+             let __q =
+               object
+                 method users = users
+               end
+             in
              object
+               method x = __q#users#query (fun __q -> __q#x)
                method users = users
              end))
       ~select:(fun __q ->
         object
-          method x = __q#users#query (fun __q -> __q#x)
+          method x = __q#x
         end)
       ~where:(fun __q ->
         Ch_queries.in_
@@ -29,12 +35,18 @@ test IN expression with subquery:
                      (Ch_queries.from
                         (Ch_database.Public.users ~alias:"users" ~final:false))
                      (fun (users : _ Ch_queries.scope) ->
+                       let __q =
+                         object
+                           method users = users
+                         end
+                       in
                        object
+                         method _1 = __q#users#query (fun __q -> __q#id)
                          method users = users
                        end))
                 ~select:(fun __q ->
                   object
-                    method _1 = __q#users#query (fun __q -> __q#id)
+                    method _1 = __q#_1
                   end))))
   
   let sql, _parse_row =
@@ -63,12 +75,18 @@ test IN expression with expression::
            (Ch_queries.from
               (Ch_database.Public.users ~alias:"users" ~final:false))
            (fun (users : _ Ch_queries.scope) ->
+             let __q =
+               object
+                 method users = users
+               end
+             in
              object
+               method x = __q#users#query (fun __q -> __q#x)
                method users = users
              end))
       ~select:(fun __q ->
         object
-          method x = __q#users#query (fun __q -> __q#x)
+          method x = __q#x
         end)
       ~where:(fun __q ->
         Ch_queries.in_
@@ -99,12 +117,18 @@ test IN expression with parameter:
            (Ch_queries.from
               (Ch_database.Public.users ~alias:"users" ~final:false))
            (fun (users : _ Ch_queries.scope) ->
+             let __q =
+               object
+                 method users = users
+               end
+             in
              object
+               method x = __q#users#query (fun __q -> __q#x)
                method users = users
              end))
       ~select:(fun __q ->
         object
-          method x = __q#users#query (fun __q -> __q#x)
+          method x = __q#x
         end)
       ~where:(fun __q -> Ch_queries.in_ (__q#users#query (fun __q -> __q#id)) ids)
   >>> RUNNING

--- a/test/test_lambda.t
+++ b/test/test_lambda.t
@@ -12,18 +12,25 @@ test IN expression with subquery:
            (Ch_queries.from
               (Ch_database.Public.users ~alias:"users" ~final:false))
            (fun (users : _ Ch_queries.scope) ->
+             let __q =
+               object
+                 method users = users
+               end
+             in
              object
+               method x =
+                 Ch_queries.Expr.length
+                   (Ch_queries.Expr.arrayFilter
+                      (Ch_queries.lambda "x" (fun x ->
+                           Ch_queries.Expr.( = ) (Ch_queries.unsafe "x")
+                             (Ch_queries.int 1)))
+                      (__q#users#query (fun __q -> __q#xs)))
+  
                method users = users
              end))
       ~select:(fun __q ->
         object
-          method x =
-            Ch_queries.Expr.length
-              (Ch_queries.Expr.arrayFilter
-                 (Ch_queries.lambda "x" (fun x ->
-                      Ch_queries.Expr.( = ) (Ch_queries.unsafe "x")
-                        (Ch_queries.int 1)))
-                 (__q#users#query (fun __q -> __q#xs)))
+          method x = __q#x
         end)
   
   let sql, _parse_row =

--- a/test/test_like.t
+++ b/test/test_like.t
@@ -12,12 +12,18 @@ test IN expression with subquery:
            (Ch_queries.from
               (Ch_database.Public.users ~alias:"users" ~final:false))
            (fun (users : _ Ch_queries.scope) ->
+             let __q =
+               object
+                 method users = users
+               end
+             in
              object
+               method x = __q#users#query (fun __q -> __q#x)
                method users = users
              end))
       ~select:(fun __q ->
         object
-          method x = __q#users#query (fun __q -> __q#x)
+          method x = __q#x
         end)
       ~where:(fun __q ->
         Ch_queries.Expr.like

--- a/test/test_nested_expr.t
+++ b/test/test_nested_expr.t
@@ -114,12 +114,18 @@ The param within the scope receives the scope as argument:
         (Ch_queries.map_from_scope
            (Ch_queries.from (q1 ~alias:"q"))
            (fun (q : _ Ch_queries.scope) ->
+             let __q =
+               object
+                 method q = q
+               end
+             in
              object
+               method field = __q#q#query (fun __q -> field __q)
                method q = q
              end))
       ~select:(fun __q ->
         object
-          method field = __q#q#query (fun __q -> field __q)
+          method field = __q#field
         end)
   ;;
   

--- a/test/test_ocaml_expr.t
+++ b/test/test_ocaml_expr.t
@@ -32,11 +32,17 @@ OCaml expression in query:
         (Ch_queries.map_from_scope
            (Ch_queries.from (users ~alias:"users"))
            (fun (users : _ Ch_queries.scope) ->
+             let __q =
+               object
+                 method users = users
+               end
+             in
              object
+               method x = x + 1
                method users = users
              end))
       ~select:(fun __q ->
         object
-          method x = x + 1
+          method x = __q#x
         end)
   >>> RUNNING

--- a/test/test_query_final.t
+++ b/test/test_query_final.t
@@ -11,12 +11,18 @@ select from table with FINAL keyword:
         (Ch_queries.map_from_scope
            (Ch_queries.from (Ch_database.Public.users ~alias:"users" ~final:true))
            (fun (users : _ Ch_queries.scope) ->
+             let __q =
+               object
+                 method users = users
+               end
+             in
              object
+               method x = __q#users#query (fun __q -> __q#x)
                method users = users
              end))
       ~select:(fun __q ->
         object
-          method x = __q#users#query (fun __q -> __q#x)
+          method x = __q#x
         end)
       ~where:(fun __q -> __q#users#query (fun __q -> __q#is_active))
   
@@ -45,12 +51,18 @@ if FINAL keyword is applied to param, then it expects the table:
         (Ch_queries.map_from_scope
            (Ch_queries.from (table ~final:true ~alias:"users"))
            (fun (users : _ Ch_queries.scope) ->
+             let __q =
+               object
+                 method users = users
+               end
+             in
              object
+               method x = __q#users#query (fun __q -> __q#x)
                method users = users
              end))
       ~select:(fun __q ->
         object
-          method x = __q#users#query (fun __q -> __q#x)
+          method x = __q#x
         end)
       ~where:(fun __q -> __q#users#query (fun __q -> __q#is_active))
   

--- a/test/test_query_join.t
+++ b/test/test_query_join.t
@@ -62,14 +62,22 @@ select from a LEFT JOIN:
                   (__q#u#query (fun __q -> __q#id))
                   (__q#p#query (fun __q -> __q#user_id))))
            (fun ((u : _ Ch_queries.scope), (p : _ Ch_queries.nullable_scope)) ->
+             let __q =
+               object
+                 method u = u
+                 method p = p
+               end
+             in
              object
+               method user_id = __q#u#query (fun __q -> __q#id)
+               method user_name = __q#p#query (fun __q -> __q#name)
                method u = u
                method p = p
              end))
       ~select:(fun __q ->
         object
-          method user_id = __q#u#query (fun __q -> __q#id)
-          method user_name = __q#p#query (fun __q -> __q#name)
+          method user_id = __q#user_id
+          method user_name = __q#user_name
         end)
   >>> RUNNING
   val q :
@@ -108,14 +116,22 @@ select from an OCaml value with JOIN:
                   (__q#u#query (fun __q -> __q#id))
                   (__q#p#query (fun __q -> __q#user_id))))
            (fun ((u : _ Ch_queries.scope), (p : _ Ch_queries.nullable_scope)) ->
+             let __q =
+               object
+                 method u = u
+                 method p = p
+               end
+             in
              object
+               method user_id = __q#u#query (fun __q -> __q#id)
+               method user_name = __q#p#query (fun __q -> __q#name)
                method u = u
                method p = p
              end))
       ~select:(fun __q ->
         object
-          method user_id = __q#u#query (fun __q -> __q#id)
-          method user_name = __q#p#query (fun __q -> __q#name)
+          method user_id = __q#user_id
+          method user_name = __q#user_name
         end)
   
   let q = q (Ch_database.Public.profiles ~final:false)
@@ -178,14 +194,22 @@ splicing ocaml values into JOIN-ON:
            (fun ( ((u : _ Ch_queries.scope), (p : _ Ch_queries.nullable_scope)),
                   (p2 : _ Ch_queries.nullable_scope) )
               ->
+             let __q =
+               object
+                 method u = u
+                 method p = p
+                 method p2 = p2
+               end
+             in
              object
+               method one = Ch_queries.int 1
                method u = u
                method p = p
                method p2 = p2
              end))
       ~select:(fun __q ->
         object
-          method one = Ch_queries.int 1
+          method one = __q#one
         end)
   >>> RUNNING
   val q :

--- a/test/test_query_optional_join.t
+++ b/test/test_query_optional_join.t
@@ -28,14 +28,22 @@ optional join with a table (elimination):
                   (__q#u#query (fun __q -> __q#id))
                   (__q#p#query (fun __q -> __q#user_id))))
            (fun ((u : _ Ch_queries.scope), (p : _ Ch_queries.nullable_scope)) ->
+             let __q =
+               object
+                 method u = u
+                 method p = p
+               end
+             in
              object
+               method user_id = __q#u#query (fun __q -> __q#id)
+               method user_name = __q#p#query (fun __q -> __q#name)
                method u = u
                method p = p
              end))
       ~select:(fun __q ->
         object
-          method user_id = __q#u#query (fun __q -> __q#id)
-          method user_name = __q#p#query (fun __q -> __q#name)
+          method user_id = __q#user_id
+          method user_name = __q#user_name
         end)
   
   let sql, _parse_row =
@@ -76,14 +84,22 @@ optional join with a table (in use):
                   (__q#u#query (fun __q -> __q#id))
                   (__q#p#query (fun __q -> __q#user_id))))
            (fun ((u : _ Ch_queries.scope), (p : _ Ch_queries.nullable_scope)) ->
+             let __q =
+               object
+                 method u = u
+                 method p = p
+               end
+             in
              object
+               method user_id = __q#u#query (fun __q -> __q#id)
+               method user_name = __q#p#query (fun __q -> __q#name)
                method u = u
                method p = p
              end))
       ~select:(fun __q ->
         object
-          method user_id = __q#u#query (fun __q -> __q#id)
-          method user_name = __q#p#query (fun __q -> __q#name)
+          method user_id = __q#user_id
+          method user_name = __q#user_name
         end)
   
   let sql, _parse_row =
@@ -123,13 +139,20 @@ optional join with a subquery (elimination):
                          (Ch_queries.from
                             (Ch_database.Public.profiles ~alias:"p" ~final:false))
                          (fun (p : _ Ch_queries.scope) ->
+                           let __q =
+                             object
+                               method p = p
+                             end
+                           in
                            object
+                             method user_id = __q#p#query (fun __q -> __q#user_id)
+                             method name = __q#p#query (fun __q -> __q#name)
                              method p = p
                            end))
                     ~select:(fun __q ->
                       object
-                        method user_id = __q#p#query (fun __q -> __q#user_id)
-                        method name = __q#p#query (fun __q -> __q#name)
+                        method user_id = __q#user_id
+                        method name = __q#name
                       end))
                  ~alias:"p")
               ~on:(fun ((u : _ Ch_queries.scope), (p : _ Ch_queries.scope)) ->
@@ -143,14 +166,22 @@ optional join with a subquery (elimination):
                   (__q#u#query (fun __q -> __q#id))
                   (__q#p#query (fun __q -> __q#user_id))))
            (fun ((u : _ Ch_queries.scope), (p : _ Ch_queries.nullable_scope)) ->
+             let __q =
+               object
+                 method u = u
+                 method p = p
+               end
+             in
              object
+               method user_id = __q#u#query (fun __q -> __q#id)
+               method user_name = __q#p#query (fun __q -> __q#name)
                method u = u
                method p = p
              end))
       ~select:(fun __q ->
         object
-          method user_id = __q#u#query (fun __q -> __q#id)
-          method user_name = __q#p#query (fun __q -> __q#name)
+          method user_id = __q#user_id
+          method user_name = __q#user_name
         end)
   
   let sql, _parse_row =
@@ -186,13 +217,20 @@ optional join with a subquery (in use):
                          (Ch_queries.from
                             (Ch_database.Public.profiles ~alias:"p" ~final:false))
                          (fun (p : _ Ch_queries.scope) ->
+                           let __q =
+                             object
+                               method p = p
+                             end
+                           in
                            object
+                             method user_id = __q#p#query (fun __q -> __q#user_id)
+                             method name = __q#p#query (fun __q -> __q#name)
                              method p = p
                            end))
                     ~select:(fun __q ->
                       object
-                        method user_id = __q#p#query (fun __q -> __q#user_id)
-                        method name = __q#p#query (fun __q -> __q#name)
+                        method user_id = __q#user_id
+                        method name = __q#name
                       end))
                  ~alias:"p")
               ~on:(fun ((u : _ Ch_queries.scope), (p : _ Ch_queries.scope)) ->
@@ -206,14 +244,22 @@ optional join with a subquery (in use):
                   (__q#u#query (fun __q -> __q#id))
                   (__q#p#query (fun __q -> __q#user_id))))
            (fun ((u : _ Ch_queries.scope), (p : _ Ch_queries.nullable_scope)) ->
+             let __q =
+               object
+                 method u = u
+                 method p = p
+               end
+             in
              object
+               method user_id = __q#u#query (fun __q -> __q#id)
+               method user_name = __q#p#query (fun __q -> __q#name)
                method u = u
                method p = p
              end))
       ~select:(fun __q ->
         object
-          method user_id = __q#u#query (fun __q -> __q#id)
-          method user_name = __q#p#query (fun __q -> __q#name)
+          method user_id = __q#user_id
+          method user_name = __q#user_name
         end)
   
   let sql, _parse_row =

--- a/test/test_union.t
+++ b/test/test_union.t
@@ -28,12 +28,18 @@ UNION syntax:
               (Ch_queries.from
                  (Ch_database.Public.users ~alias:"users" ~final:false))
               (fun (users : _ Ch_queries.scope) ->
+                let __q =
+                  object
+                    method users = users
+                  end
+                in
                 object
+                  method x = Ch_queries.int 1
                   method users = users
                 end))
          ~select:(fun __q ->
            object
-             method x = Ch_queries.int 1
+             method x = __q#x
            end))
       (Ch_queries.select ()
          ~from:
@@ -41,12 +47,18 @@ UNION syntax:
               (Ch_queries.from
                  (Ch_database.Public.users ~alias:"users" ~final:false))
               (fun (users : _ Ch_queries.scope) ->
+                let __q =
+                  object
+                    method users = users
+                  end
+                in
                 object
+                  method x = Ch_queries.int 2
                   method users = users
                 end))
          ~select:(fun __q ->
            object
-             method x = Ch_queries.int 2
+             method x = __q#x
            end))
   
   let sql, _parse_row =

--- a/test/test_with_prefix.t
+++ b/test/test_with_prefix.t
@@ -11,12 +11,18 @@ all syntax forms can be used with `%ch.*` prefix as well, we test just the `%ch.
            (Ch_queries.from
               (Ch_database.Public.users ~alias:"users" ~final:false))
            (fun (users : _ Ch_queries.scope) ->
+             let __q =
+               object
+                 method users = users
+               end
+             in
              object
+               method x = __q#users#query (fun __q -> __q#x)
                method users = users
              end))
       ~select:(fun __q ->
         object
-          method x = __q#users#query (fun __q -> __q#x)
+          method x = __q#x
         end)
       ~where:(fun __q -> __q#users#query (fun __q -> __q#is_active))
   >>> RUNNING


### PR DESCRIPTION
Previously we have been resolved unqualified column names to FROM element if it was only a single scope in query (no JOIN):

    SELECT x FROM table
           ^ resolved as table.x

Now instead we resolve it to columns defined in SELECT, so it is possible to reuse expressions in WHERE/GROUP BY/...

    SELECT table.x AS key
    FROM table
    GROUP BY key
             ^ resolved as table.x, according to SELECT

Possible extension is to add WITH fields... construct.
