### PR TITLE
misc fixes made during adaptation for grafana

### DIFF
--- a/ch_queries/ch_queries.ml
+++ b/ch_queries/ch_queries.ml
@@ -7,6 +7,7 @@ type 'a number = private A_number
 type 'a timestamp = private A_timestamp
 type date = private Date
 type datetime = private DateTime
+type datetime64 = private DateTime64
 type ('null, 'a) array = private A_array
 type ('nullk, 'k, 'nullv, 'v) map = private A_map
 type ('null, 'a) typ = private A_typ
@@ -479,7 +480,7 @@ module Expr = struct
 
   (** {2 String replacement} *)
 
-  let replaceOne hay needle = def "replaceOne" [ hay; needle ]
+  let replaceOne hay needle replacement = def "replaceOne" [ hay; needle; replacement ]
 
   (** {2 String search} *)
 
@@ -487,7 +488,8 @@ module Expr = struct
 
   (** {2 Type conversions} *)
 
-  let toUInt64 x = def "toUint64" [ x ]
+  let toInt64 x = def "toInt64" [ x ]
+  let toUInt64 x = def "toUInt64" [ x ]
 
   (** {1 Aggregate functions} *)
 
@@ -688,6 +690,7 @@ module Row = struct
   let float expr = Row_col_number (expr, float_of_json)
   let float_opt expr = Row_col_number_opt (expr, float_of_json)
   let any f expr = Row_col (expr, f)
+  let ignore expr = Row_col (expr, ignore)
 
   let parse : type a. a t -> json list -> a =
     let rec aux : type a. a t -> json list -> a * json list =

--- a/ch_queries/ch_queries.mli
+++ b/ch_queries/ch_queries.mli
@@ -14,6 +14,7 @@ type ('null, 'a) typ = private A_typ
 type ('x, 'y) tuple2 = private A_tuple2
 type date = private Date
 type datetime = private DateTime
+type datetime64 = private DateTime64
 type interval = private Interval
 
 type (+'null, +'typ) expr
@@ -191,20 +192,20 @@ module Expr : sig
   val notEquals : ('n, 'a) expr -> ('n, 'a) expr -> ('n, bool) expr
   val ( != ) : ('n, 'a) expr -> ('n, 'a) expr -> ('n, bool) expr
   val ( <> ) : ('n, 'a) expr -> ('n, 'a) expr -> ('n, bool) expr
-  val greater : ('n, 'a number) expr -> ('n, 'a number) expr -> ('n, bool) expr
-  val ( > ) : ('n, 'a number) expr -> ('n, 'a number) expr -> ('n, bool) expr
-  val less : ('n, 'a number) expr -> ('n, 'a number) expr -> ('n, bool) expr
-  val ( < ) : ('n, 'a number) expr -> ('n, 'a number) expr -> ('n, bool) expr
+  val greater : ('n, 'a number) expr -> ('n, 'b number) expr -> ('n, bool) expr
+  val ( > ) : ('n, 'a number) expr -> ('n, 'b number) expr -> ('n, bool) expr
+  val less : ('n, 'a number) expr -> ('n, 'b number) expr -> ('n, bool) expr
+  val ( < ) : ('n, 'a number) expr -> ('n, 'b number) expr -> ('n, bool) expr
 
   val greaterOrEquals :
-    ('n, 'a number) expr -> ('n, 'a number) expr -> ('n, bool) expr
+    ('n, 'a number) expr -> ('n, 'b number) expr -> ('n, bool) expr
 
-  val ( >= ) : ('n, 'a number) expr -> ('n, 'a number) expr -> ('n, bool) expr
+  val ( >= ) : ('n, 'a number) expr -> ('n, 'b number) expr -> ('n, bool) expr
 
   val lessOrEquals :
-    ('n, 'a number) expr -> ('n, 'a number) expr -> ('n, bool) expr
+    ('n, 'a number) expr -> ('n, 'b number) expr -> ('n, bool) expr
 
-  val ( <= ) : ('n, 'a number) expr -> ('n, 'a number) expr -> ('n, bool) expr
+  val ( <= ) : ('n, 'a number) expr -> ('n, 'b number) expr -> ('n, bool) expr
 
   (** {2 Dates and times} *)
 
@@ -308,7 +309,10 @@ module Expr : sig
   (** {2 String replacement} *)
 
   val replaceOne :
-    ('n, string) expr -> (non_null, string) expr -> ('n, string) expr
+    ('n, string) expr ->
+    (non_null, string) expr ->
+    (non_null, string) expr ->
+    ('n, string) expr
 
   (** {2 String search} *)
 
@@ -316,6 +320,7 @@ module Expr : sig
 
   (** {2 Type conversions} *)
 
+  val toInt64 : ('n, string) expr -> ('n, int number) expr
   val toUInt64 : ('n, string) expr -> ('n, int number) expr
 
   (** {1 Aggregate functions} *)
@@ -385,6 +390,7 @@ module Row : sig
   val float : (non_null, float number) expr -> float t
   val float_opt : ([< null ], float number) expr -> float option t
   val any : (json -> 'a) -> _ expr -> 'a t
+  val ignore : ('n, 'a) expr -> unit t
 
   exception Parse_error of json option * string
 


### PR DESCRIPTION
- replaceOne had the wrong arity.
- Typo in `toUInt64`
- Add `ignore` function in `Row` to get a column in the final but do nothing with it.
- Add Datetime64 type (for sub-second precision)
- Make comparisons work on different number types. `12.5 > 10` is supported by clickhouse, and does not have any issue in principle.
- Normalization for column names so that they fit lexical convention for method names (no leading capital letter and no dot) 