### PR TITLE
QUALIFY is after GROUP BY

### DIFF
--- a/ch_queries_syntax/parser.mly
+++ b/ch_queries_syntax/parser.mly
@@ -120,7 +120,7 @@ a_from:
     FROM f=from EOF { f }
 
 query_select:
-  with_fields=with_fields? SELECT select=select FROM from=from prewhere=prewhere? where=where? qualify=qualify? group_by=group_by? having=having? order_by=order_by? limits=limit_by_and_limit offset=offset? settings=settings?
+  with_fields=with_fields? SELECT select=select FROM from=from prewhere=prewhere? where=where? group_by=group_by? having=having? qualify=qualify? order_by=order_by? limits=limit_by_and_limit offset=offset? settings=settings?
   { let limit_by, limit = limits in
     make_query $startpos $endpos (Syntax.Q_select { with_fields = Option.value with_fields ~default:[]; select; from; prewhere; where; qualify; group_by; having; order_by; limit_by; limit; offset; settings = Option.value settings ~default:[] }) }
 

--- a/ch_queries_syntax/printer.ml
+++ b/ch_queries_syntax/printer.ml
@@ -563,9 +563,9 @@ and pp_query opts { node; eq = _; loc = _ } =
                 Some from;
                 prewhere;
                 where;
-                qualify;
                 group_by;
                 having;
+                qualify;
                 order_by;
                 limit_by;
                 limit;

--- a/test/test_query_window_frame.t
+++ b/test/test_query_window_frame.t
@@ -163,6 +163,24 @@ Window frame with GROUP BY:
   FROM public.users AS users
   GROUP BY users.x
 
+Window frame mixed with GROUP BY and QUALIFY:
+
+  $ ./compile_and_run "
+  > let users = [%q {q|SELECT users.x AS x, sum(users.id)over(partition by users.x order by users.id rows between unbounded preceding and current row) AS s FROM public.users GROUP BY users.x QUALIFY sum(users.id)over(partition by users.x order by users.id rows between unbounded preceding and current row) > 0|q}];;
+  > let sql, _parse_row = Ch_queries.query users @@ fun __q -> Ch_queries.Row.ignore [%e {e|q.s|e}];;
+  > let () = print_endline sql;;
+  > " --run-only
+  >>> RUNNING
+  SELECT
+    sum(users.id) OVER (PARTITION BY users.x ORDER BY users.id ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+      AS s
+  FROM public.users AS users
+  GROUP BY users.x
+  QUALIFY
+  sum(users.id) OVER (PARTITION BY users.x ORDER BY users.id ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+  >
+  0
+
 range() still works as a function despite RANGE keyword:
 
   $ ./compile_and_run "


### PR DESCRIPTION
Just switch the order of QUALIFY and GROUP BY.

Could not find doc that says this should be the case, but running the following command showcases the issue:

 Fails (QUALIFY before GROUP BY):
```bash
$  clickhouse-local --query "SELECT users.x FROM (SELECT 1 AS id, 'a' AS x) AS users QUALIFY count() OVER () > 0 GROUP BY users.x"
Code: 62. DB::Exception: Syntax error: failed at position 85 (GROUP): GROUP BY users.x. Expected one of: token, DoubleColon, OR, AND, IS NOT DISTINCT FROM, IS DISTINCT FROM, IS NULL, IS NOT NULL, BETWEEN, NOT BETWEEN, LIKE, ILIKE, NOT LIKE, NOT ILIKE, REGEXP, IN, NOT IN, GLOBAL IN, GLOBAL NOT IN, MOD, DIV, alias, AS, ORDER BY, LIMIT, OFFSET, FETCH, SETTINGS, UNION, EXCEPT, INTERSECT, INTO OUTFILE, FORMAT, ParallelWithClause, PARALLEL WITH, end of query. (SYNTAX_ERROR)
```

Succeeds (GROUP BY before QUALIFY):
```bash
$  clickhouse-local --query "SELECT users.x FROM (SELECT 1 AS id, 'a' AS x) AS users GROUP BY users.x QUALIFY count() OVER () > 0"
a
```